### PR TITLE
Update module for 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  terraform:
+    name: Terraform validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.4
+          terraform_wrapper: false
+
+      - name: terraform fmt
+        run: terraform fmt -check -recursive -diff
+
+      - name: terraform init
+        run: terraform init -backend=false -input=false
+
+      - name: terraform validate
+        run: terraform validate
+
+  python:
+    name: Python compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: py_compile
+        run: python -m py_compile functions/ebs_snapshot_lambda.py functions/ebs_cleanup_lambda.py


### PR DESCRIPTION
Brings `ebs-snapshots-tf` (last commit 2018) forward to a working 2026 toolchain.

## Summary

- Pin `terraform >= 1.9.0`, `aws ~> 5.80`, `archive ~> 2.4` (new `versions.tf`).
- Migrate every `.tf` file from Terraform 0.11 syntax to 1.x (drop `"${...}"` wrappers, fix quoted type declarations, `map(...)` → object literals, fix nested-interpolation ternary).
- Replace deprecated provider surfaces: `aws_s3_bucket_object` → `aws_s3_object`; `aws_cloudwatch_event_rule.is_enabled` → `state`; `aws_iam_policy_attachment` → `aws_iam_role_policy_attachment`.
- Bump Lambda runtime `python2.7` → `python3.13` (sources already Py3-clean).
- Modernise README (compatibility section, 1.x example, valid 12-digit placeholder account, typo fixes).
- Add `NOTICE` (2018-2026 copyright) and `CHANGELOG.md`.
- Add `.github/workflows/ci.yml` that runs `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate`, and `python -m py_compile` on every push and PR.

## Validation

CI on `4430ab5` is green: https://github.com/calvin-j/ebs-snapshots-tf/actions?query=branch%3Aclaude%2Fupdate-2026-nrOiS — both the Terraform and Python jobs passed.

## Note on state migration

The deprecated-resource renames change resource addresses, so any existing deployment will need `terraform state mv` for:

- `aws_s3_bucket_object.snapshot_lambda` → `aws_s3_object.snapshot_lambda`
- `aws_s3_bucket_object.cleanup_lambda` → `aws_s3_object.cleanup_lambda`
- `module.lambda_ebs_snapshots.aws_iam_policy_attachment.logging` → `module.lambda_ebs_snapshots.aws_iam_role_policy_attachment.logging`
- `module.lambda_ebs_snapshots_cleanup.aws_iam_policy_attachment.logging` → `module.lambda_ebs_snapshots_cleanup.aws_iam_role_policy_attachment.logging`

This is also called out in `CHANGELOG.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1bQfgZRAGSdq3noZgvPTt)_